### PR TITLE
Fix inserting falsy values as data

### DIFF
--- a/lib/treap.js
+++ b/lib/treap.js
@@ -18,7 +18,7 @@ var treap = (typeof exports === 'undefined') ? {} : exports;
 
       // Create the node and randomly assign it a priority
       var node = {key: key, priority: Math.random(), size: 1};
-      if (data) node.data = data;
+      if (data !== undefined) node.data = data;
 
       // Perform the insertion of the node as for a normal BST
       var parentNode = this._search(key);

--- a/test/tests.js
+++ b/test/tests.js
@@ -25,7 +25,6 @@ describe('performing insertions', function() {
   });
 });
 
-
 describe('performing lookups', function() {
   var t = treap.create();
 
@@ -120,3 +119,30 @@ describe('splitting and merging', function() {
     mergedTreap.find(50).key.should.equal(50)
   });
 });
+
+describe('data', function() {
+  var t = treap.create();
+
+  it('inserts falsy data values', function() {
+    // https://developer.mozilla.org/en-US/docs/Glossary/Falsy
+    var falsyValues = [
+      false,
+      null,
+      undefined,  // ok to include
+      0,
+      NaN,
+      '',
+      "",
+      ``,
+    ];
+    var found;
+    falsyValues.map(function(value, key) {
+      t.insert(key, value)
+    });
+
+    found = t.findRange(0, falsyValues.length);
+    found.map(function(node) {
+      return node.data;
+    }).should.eql(falsyValues);
+  });
+})


### PR DESCRIPTION
I noticed that for example value `0`would not be inserted as data.
This is now fixed with a test along with other [falsy values](https://developer.mozilla.org/en-US/docs/Glossary/Falsy).